### PR TITLE
feat: 할 일 위젯 추가

### DIFF
--- a/TodoList/TodoList.xcodeproj/project.pbxproj
+++ b/TodoList/TodoList.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -24,10 +24,14 @@
 		EA52F265253B129D009286D4 /* CategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA52F263253B129D009286D4 /* CategoryViewController.swift */; };
 		EA52F2D32541736C009286D4 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA52F2D12541736C009286D4 /* ContentViewController.swift */; };
 		EA9C3CA5254A8F4000DE9475 /* AddTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9C3CA3254A8F4000DE9475 /* AddTodoViewController.swift */; };
-		EAD3912747EAC4D8BB139EE0 /* EditTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD3912747EAC4D8BB139EE1 /* EditTodoViewController.swift */; };
-		EAFB86C825428C640037390E /* ContentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFB86C625428C640037390E /* ContentTableViewCell.swift */; };
 		EAAA00012E8F0A0000000000 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAA00002E8F0A0000000000 /* SettingsViewController.swift */; };
 		EAAA00032E8F0B0000000000 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAA00022E8F0B0000000000 /* SettingsViewModel.swift */; };
+		EAD3912747EAC4D8BB139EE0 /* EditTodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD3912747EAC4D8BB139EE1 /* EditTodoViewController.swift */; };
+		EAEFCC6B2EB394AB004C1830 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAEFCC6A2EB394AB004C1830 /* WidgetKit.framework */; };
+		EAEFCC6D2EB394AB004C1830 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAEFCC6C2EB394AB004C1830 /* SwiftUI.framework */; };
+		EAEFCC7E2EB394AC004C1830 /* TodoListWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EAEFCC682EB394AB004C1830 /* TodoListWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		EAEFCC8C2EB39D37004C1830 /* TodoList.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = EA52F20D2539981D009286D4 /* TodoList.xcdatamodeld */; };
+		EAFB86C825428C640037390E /* ContentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFB86C625428C640037390E /* ContentTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,7 +49,28 @@
 			remoteGlobalIDString = EA52F2002539981D009286D4;
 			remoteInfo = TodoList;
 		};
+		EAEFCC7C2EB394AC004C1830 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EA52F1F92539981D009286D4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EAEFCC672EB394AB004C1830;
+			remoteInfo = TodoListWidgetExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		EAEFCC7F2EB394AC004C1830 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				EAEFCC7E2EB394AC004C1830 /* TodoListWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		EA402DC4256687A400C51D85 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
@@ -70,11 +95,30 @@
 		EA52F263253B129D009286D4 /* CategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewController.swift; sourceTree = "<group>"; };
 		EA52F2D12541736C009286D4 /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
 		EA9C3CA3254A8F4000DE9475 /* AddTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoViewController.swift; sourceTree = "<group>"; };
-		EAD3912747EAC4D8BB139EE1 /* EditTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTodoViewController.swift; sourceTree = "<group>"; };
-		EAFB86C625428C640037390E /* ContentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTableViewCell.swift; sourceTree = "<group>"; };
 		EAAA00002E8F0A0000000000 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		EAAA00022E8F0B0000000000 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		EAD3912747EAC4D8BB139EE1 /* EditTodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTodoViewController.swift; sourceTree = "<group>"; };
+		EAEFCC682EB394AB004C1830 /* TodoListWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TodoListWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAEFCC6A2EB394AB004C1830 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		EAEFCC6C2EB394AB004C1830 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		EAEFCC842EB395DA004C1830 /* TodoList.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TodoList.entitlements; sourceTree = "<group>"; };
+		EAEFCC852EB395FF004C1830 /* TodoListWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TodoListWidgetExtension.entitlements; sourceTree = "<group>"; };
+		EAFB86C625428C640037390E /* ContentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		EAEFCC822EB394AC004C1830 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = EAEFCC672EB394AB004C1830 /* TodoListWidgetExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		EAEFCC6E2EB394AB004C1830 /* TodoListWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (EAEFCC822EB394AC004C1830 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TodoListWidget; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		EA52F1FE2539981D009286D4 /* Frameworks */ = {
@@ -96,6 +140,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEFCC652EB394AB004C1830 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAEFCC6D2EB394AB004C1830 /* SwiftUI.framework in Frameworks */,
+				EAEFCC6B2EB394AB004C1830 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,9 +176,12 @@
 		EA52F1F82539981D009286D4 = {
 			isa = PBXGroup;
 			children = (
+				EAEFCC852EB395FF004C1830 /* TodoListWidgetExtension.entitlements */,
 				EA52F2032539981D009286D4 /* TodoList */,
 				EA52F21D25399820009286D4 /* TodoListTests */,
 				EA52F22825399820009286D4 /* TodoListUITests */,
+				EAEFCC6E2EB394AB004C1830 /* TodoListWidget */,
+				EAEFCC692EB394AB004C1830 /* Frameworks */,
 				EA52F2022539981D009286D4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -136,6 +192,7 @@
 				EA52F2012539981D009286D4 /* TodoList.app */,
 				EA52F21A25399820009286D4 /* TodoListTests.xctest */,
 				EA52F22525399820009286D4 /* TodoListUITests.xctest */,
+				EAEFCC682EB394AB004C1830 /* TodoListWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -143,6 +200,7 @@
 		EA52F2032539981D009286D4 /* TodoList */ = {
 			isa = PBXGroup;
 			children = (
+				EAEFCC842EB395DA004C1830 /* TodoList.entitlements */,
 				EA402DCC2566967A00C51D85 /* Model */,
 				EA402DC32566878A00C51D85 /* ViewModel */,
 				EA52F23B2539C065009286D4 /* Cell */,
@@ -198,6 +256,15 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		EAEFCC692EB394AB004C1830 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EAEFCC6A2EB394AB004C1830 /* WidgetKit.framework */,
+				EAEFCC6C2EB394AB004C1830 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		EAFB86C425428C340037390E /* CollectionViewCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -224,10 +291,12 @@
 				EA52F1FD2539981D009286D4 /* Sources */,
 				EA52F1FE2539981D009286D4 /* Frameworks */,
 				EA52F1FF2539981D009286D4 /* Resources */,
+				EAEFCC7F2EB394AC004C1830 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				EAEFCC7D2EB394AC004C1830 /* PBXTargetDependency */,
 			);
 			name = TodoList;
 			productName = TodoList;
@@ -270,13 +339,35 @@
 			productReference = EA52F22525399820009286D4 /* TodoListUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		EAEFCC672EB394AB004C1830 /* TodoListWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EAEFCC832EB394AC004C1830 /* Build configuration list for PBXNativeTarget "TodoListWidgetExtension" */;
+			buildPhases = (
+				EAEFCC642EB394AB004C1830 /* Sources */,
+				EAEFCC652EB394AB004C1830 /* Frameworks */,
+				EAEFCC662EB394AB004C1830 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				EAEFCC6E2EB394AB004C1830 /* TodoListWidget */,
+			);
+			name = TodoListWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = TodoListWidgetExtension;
+			productReference = EAEFCC682EB394AB004C1830 /* TodoListWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		EA52F1F92539981D009286D4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1200;
+				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 1200;
 				TargetAttributes = {
 					EA52F2002539981D009286D4 = {
@@ -289,6 +380,9 @@
 					EA52F22425399820009286D4 = {
 						CreatedOnToolsVersion = 12.0.1;
 						TestTargetID = EA52F2002539981D009286D4;
+					};
+					EAEFCC672EB394AB004C1830 = {
+						CreatedOnToolsVersion = 26.0.1;
 					};
 				};
 			};
@@ -311,6 +405,7 @@
 				EA52F2002539981D009286D4 /* TodoList */,
 				EA52F21925399820009286D4 /* TodoListTests */,
 				EA52F22425399820009286D4 /* TodoListUITests */,
+				EAEFCC672EB394AB004C1830 /* TodoListWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -334,6 +429,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		EA52F22325399820009286D4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EAEFCC662EB394AB004C1830 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -381,6 +483,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EAEFCC642EB394AB004C1830 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EAEFCC8C2EB39D37004C1830 /* TodoList.xcdatamodeld in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -393,6 +503,11 @@
 			isa = PBXTargetDependency;
 			target = EA52F2002539981D009286D4 /* TodoList */;
 			targetProxy = EA52F22625399820009286D4 /* PBXContainerItemProxy */;
+		};
+		EAEFCC7D2EB394AC004C1830 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EAEFCC672EB394AB004C1830 /* TodoListWidgetExtension */;
+			targetProxy = EAEFCC7C2EB394AC004C1830 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -537,6 +652,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TodoList/TodoList.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = U53BLS7M93;
@@ -562,6 +678,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TodoList/TodoList.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = U53BLS7M93;
@@ -666,6 +783,83 @@
 			};
 			name = Release;
 		};
+		EAEFCC802EB394AC004C1830 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = TodoListWidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U53BLS7M93;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TodoListWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TodoListWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = key.TodoList.TodoListWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EAEFCC812EB394AC004C1830 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = TodoListWidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U53BLS7M93;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TodoListWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TodoListWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = key.TodoList.TodoListWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -701,6 +895,15 @@
 			buildConfigurations = (
 				EA52F23525399820009286D4 /* Debug */,
 				EA52F23625399820009286D4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EAEFCC832EB394AC004C1830 /* Build configuration list for PBXNativeTarget "TodoListWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EAEFCC802EB394AC004C1830 /* Debug */,
+				EAEFCC812EB394AC004C1830 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TodoList/TodoList/AppDelegate.swift
+++ b/TodoList/TodoList/AppDelegate.swift
@@ -42,11 +42,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          error conditions that could cause the creation of the store to fail.
         */
         let container = NSPersistentContainer(name: "TodoList")
+
+        // App Group을 사용하여 위젯과 데이터 공유
+        let storeURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.key.TodoList")?
+            .appendingPathComponent("TodoList.sqlite")
+
+        if let storeURL = storeURL {
+            let storeDescription = NSPersistentStoreDescription(url: storeURL)
+            container.persistentStoreDescriptions = [storeDescription]
+            print("✅ Using App Group store at: \(storeURL)")
+        } else {
+            print("❌ Failed to get App Group container URL")
+        }
+
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
+
                 /*
                  Typical reasons for an error here include:
                  * The parent directory does not exist, cannot be created, or disallows writing.
@@ -55,7 +68,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                  * The store could not be migrated to the current model version.
                  Check the error message to determine what the actual problem was.
                  */
+                print("❌ Core Data error: \(error), \(error.userInfo)")
                 fatalError("Unresolved error \(error), \(error.userInfo)")
+            } else {
+                print("✅ Main app Core Data loaded successfully")
             }
         })
         return container

--- a/TodoList/TodoList/TodoList.entitlements
+++ b/TodoList/TodoList/TodoList.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.key.TodoList</string>
+	</array>
+</dict>
+</plist>

--- a/TodoList/TodoList/View/AddTodoViewController.swift
+++ b/TodoList/TodoList/View/AddTodoViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import CoreData
 import SnapKit
+import WidgetKit
 
 class AddTodoViewController: UIViewController {
     // MARK: - UI Components
@@ -132,6 +133,10 @@ class AddTodoViewController: UIViewController {
         viewModel?.saveData(entityName: "Todo", categoryName: categoryName, todoName: todoName, date: date, dueDate: selectedDueDate, isCompleted: false) { [weak self] success, errorMessage in
             DispatchQueue.main.async {
                 if success {
+                    // 위젯 새로고침
+                    WidgetCenter.shared.reloadTimelines(ofKind: "TodoListWidget")
+                    print("✅ Widget refreshed after adding todo")
+
                     let impact = UIImpactFeedbackGenerator(style: .light)
                     impact.impactOccurred()
                     self?.navigationController?.popViewController(animated: true)

--- a/TodoList/TodoList/View/ContentViewController.swift
+++ b/TodoList/TodoList/View/ContentViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import CoreData
 import SnapKit
+import WidgetKit
 
 class ContentViewController: UIViewController {
     
@@ -296,13 +297,17 @@ class ContentViewController: UIViewController {
     
     private func saveContext() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-        
+
         let context = appDelegate.persistentContainer.viewContext
-        
+
         if context.hasChanges {
             do {
                 try context.save()
                 print("✅ Context saved successfully")
+
+                // 위젯 새로고침
+                WidgetCenter.shared.reloadTimelines(ofKind: "TodoListWidget")
+                print("✅ Widget refreshed")
             } catch let error as NSError {
                 print("❌ Could not save context: \(error), \(error.userInfo)")
             }

--- a/TodoList/TodoListWidget/AppIntent.swift
+++ b/TodoList/TodoListWidget/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  TodoListWidget
+//
+//  Created by 김기현 on 10/30/25.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/TodoList/TodoListWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TodoList/TodoListWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoList/TodoListWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TodoList/TodoListWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoList/TodoListWidget/Assets.xcassets/Contents.json
+++ b/TodoList/TodoListWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoList/TodoListWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/TodoList/TodoListWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoList/TodoListWidget/Info.plist
+++ b/TodoList/TodoListWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/TodoList/TodoListWidget/RefreshIntent.swift
+++ b/TodoList/TodoListWidget/RefreshIntent.swift
@@ -1,0 +1,17 @@
+import Foundation
+import AppIntents
+import WidgetKit
+
+struct RefreshIntent: AppIntent {
+    static var title: LocalizedStringResource = "위젯 새로고침"
+    static var description = IntentDescription("할 일 위젯을 새로고침합니다")
+
+    func perform() async throws -> some IntentResult {
+        print("🔄 RefreshIntent: 새로고침 버튼 클릭됨")
+
+        // 위젯 새로고침
+        WidgetCenter.shared.reloadTimelines(ofKind: "TodoListWidget")
+
+        return .result()
+    }
+}

--- a/TodoList/TodoListWidget/TodoListWidget.swift
+++ b/TodoList/TodoListWidget/TodoListWidget.swift
@@ -1,0 +1,208 @@
+//
+//  TodoListWidget.swift
+//  TodoListWidget
+//
+//  Created by 김기현 on 10/30/25.
+//
+
+import WidgetKit
+import SwiftUI
+import CoreData
+import AppIntents
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> TodoEntry {
+        print("🔄 Widget: placeholder called")
+        return TodoEntry(date: Date(), totalTasks: 0, completedTasks: 0)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (TodoEntry) -> ()) {
+        print("📸 Widget: getSnapshot called")
+        let (totalTasks, completedTasks) = fetchTodoData()
+        let entry = TodoEntry(date: Date(), totalTasks: totalTasks, completedTasks: completedTasks)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        print("⏰ Widget: getTimeline called - START")
+        let currentDate = Date()
+
+        // Core Data에서 실제 데이터 가져오기
+        let (totalTasks, completedTasks) = fetchTodoData()
+
+        let entry = TodoEntry(
+            date: currentDate,
+            totalTasks: totalTasks,
+            completedTasks: completedTasks
+        )
+
+        print("📊 Widget timeline: \(entry.completedTasks)/\(entry.totalTasks) at \(currentDate)")
+
+        // 매시간 새로고침
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        print("⏰ Widget: getTimeline called - END")
+        completion(timeline)
+    }
+
+    private func fetchTodoData() -> (total: Int, completed: Int) {
+        print("🔍 Widget: fetchTodoData started")
+
+        // App Group 컨테이너 확인
+        guard let storeURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.key.TodoList") else {
+            print("❌ Widget: Failed to get App Group container")
+            return (0, 0)
+        }
+
+        let finalStoreURL = storeURL.appendingPathComponent("TodoList.sqlite")
+        print("🔍 Widget: Looking for database at: \(finalStoreURL.path)")
+
+        // 파일 존재 확인
+        if !FileManager.default.fileExists(atPath: finalStoreURL.path) {
+            print("❌ Widget: Database file does not exist")
+
+            // 앱 그룹 디렉토리 내용 확인
+            do {
+                let contents = try FileManager.default.contentsOfDirectory(atPath: storeURL.path)
+                print("📁 Widget: App Group contents: \(contents)")
+            } catch {
+                print("❌ Widget: Cannot read App Group directory: \(error)")
+            }
+
+            return (0, 0)
+        }
+
+        // 간단한 Core Data 설정
+        let container = NSPersistentContainer(name: "TodoList")
+        let storeDescription = NSPersistentStoreDescription(url: finalStoreURL)
+        storeDescription.setOption(true as NSNumber, forKey: NSReadOnlyPersistentStoreOption)
+        container.persistentStoreDescriptions = [storeDescription]
+
+        var loadError: Error?
+        container.loadPersistentStores { description, error in
+            loadError = error
+            if let error = error {
+                print("❌ Widget: Core Data error: \(error)")
+            } else {
+                print("✅ Widget: Core Data loaded from \(description.url?.path ?? "unknown")")
+            }
+        }
+
+        guard loadError == nil else {
+            print("❌ Widget: Failed to load persistent stores")
+            return (0, 0)
+        }
+
+        let context = container.viewContext
+        let request = NSFetchRequest<NSManagedObject>(entityName: "Todo")
+
+        do {
+            let todos = try context.fetch(request)
+            let totalTasks = todos.count
+            let completedTasks = todos.filter { todo in
+                return (todo.value(forKey: "isCompleted") as? Bool) ?? false
+            }.count
+
+            print("✅ Widget: Found \(totalTasks) total, \(completedTasks) completed")
+            return (totalTasks, completedTasks)
+        } catch {
+            print("❌ Widget: Fetch error: \(error)")
+            return (0, 0)
+        }
+    }
+}
+
+struct TodoEntry: TimelineEntry {
+    let date: Date
+    let totalTasks: Int
+    let completedTasks: Int
+
+    var completionPercentage: Double {
+        guard totalTasks > 0 else { return 0 }
+        return Double(completedTasks) / Double(totalTasks)
+    }
+}
+
+struct TodoListWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack(spacing: 6) {
+            // 제목
+            HStack {
+                Image(systemName: "checklist")
+                    .foregroundColor(.blue)
+                    .font(.system(size: 14))
+                Text("할 일")
+                    .font(.system(size: 14, weight: .semibold))
+                Spacer()
+            }
+
+            // 진행률 정보
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("\(entry.completedTasks)/\(entry.totalTasks)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Spacer()
+                    Text("\(Int(entry.completionPercentage * 100))%")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                // 진행률 바
+                ProgressView(value: entry.completionPercentage)
+                    .progressViewStyle(LinearProgressViewStyle(tint: .blue))
+                    .scaleEffect(x: 1, y: 2, anchor: .center)
+            }
+
+            // 완료 상태 텍스트
+            HStack {
+                if entry.totalTasks == 0 {
+                    Text("할 일이 없습니다")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else if entry.completedTasks == entry.totalTasks {
+                    Text("모든 할 일 완료! 🎉")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                } else {
+                    Text("\(entry.totalTasks - entry.completedTasks)개 남음")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+
+            // 업데이트 시간
+            HStack {
+                Spacer()
+                Text(entry.date, style: .time)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct TodoListWidget: Widget {
+    let kind: String = "TodoListWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            TodoListWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("할 일 진행률")
+        .description("할 일의 완료 진행률을 확인하세요.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+#Preview(as: .systemSmall) {
+    TodoListWidget()
+} timeline: {
+    TodoEntry(date: Date(), totalTasks: 8, completedTasks: 5)
+    TodoEntry(date: Date(), totalTasks: 3, completedTasks: 3)
+}

--- a/TodoList/TodoListWidget/TodoListWidget.swift
+++ b/TodoList/TodoListWidget/TodoListWidget.swift
@@ -173,13 +173,22 @@ struct TodoListWidgetEntryView : View {
                 }
                 Spacer()
             }
+            
+            Spacer()
 
-            // 업데이트 시간
+            // 업데이트 시간 및 새로고침 버튼
             HStack {
                 Spacer()
                 Text(entry.date, style: .time)
                     .font(.caption2)
                     .foregroundColor(.secondary)
+
+                Button(intent: RefreshIntent()) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption2)
+                        .foregroundColor(.blue)
+                }
+                .buttonStyle(.plain)
             }
         }
         .containerBackground(.fill.tertiary, for: .widget)

--- a/TodoList/TodoListWidget/TodoListWidget.swift
+++ b/TodoList/TodoListWidget/TodoListWidget.swift
@@ -182,7 +182,6 @@ struct TodoListWidgetEntryView : View {
                     .foregroundColor(.secondary)
             }
         }
-        .padding()
         .containerBackground(.fill.tertiary, for: .widget)
     }
 }

--- a/TodoList/TodoListWidget/TodoListWidgetBundle.swift
+++ b/TodoList/TodoListWidget/TodoListWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  TodoListWidgetBundle.swift
+//  TodoListWidget
+//
+//  Created by 김기현 on 10/30/25.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct TodoListWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        TodoListWidget()
+    }
+}

--- a/TodoList/TodoListWidget/TodoListWidgetControl.swift
+++ b/TodoList/TodoListWidget/TodoListWidgetControl.swift
@@ -1,0 +1,77 @@
+//
+//  TodoListWidgetControl.swift
+//  TodoListWidget
+//
+//  Created by 김기현 on 10/30/25.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct TodoListWidgetControl: ControlWidget {
+    static let kind: String = "key.TodoList.TodoListWidget"
+
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: Self.kind,
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value.isRunning,
+                action: StartTimerIntent(value.name)
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension TodoListWidgetControl {
+    struct Value {
+        var isRunning: Bool
+        var name: String
+    }
+
+    struct Provider: AppIntentControlValueProvider {
+        func previewValue(configuration: TimerConfiguration) -> Value {
+            TodoListWidgetControl.Value(isRunning: false, name: configuration.timerName)
+        }
+
+        func currentValue(configuration: TimerConfiguration) async throws -> Value {
+            let isRunning = true // Check if the timer is running
+            return TodoListWidgetControl.Value(isRunning: isRunning, name: configuration.timerName)
+        }
+    }
+}
+
+struct TimerConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Timer Name Configuration"
+
+    @Parameter(title: "Timer Name", default: "Timer")
+    var timerName: String
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer Name")
+    var name: String
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    init() {}
+
+    init(_ name: String) {
+        self.name = name
+    }
+
+    func perform() async throws -> some IntentResult {
+        // Start the timer…
+        return .result()
+    }
+}

--- a/TodoList/TodoListWidget/TodoListWidgetLiveActivity.swift
+++ b/TodoList/TodoListWidget/TodoListWidgetLiveActivity.swift
@@ -1,0 +1,80 @@
+//
+//  TodoListWidgetLiveActivity.swift
+//  TodoListWidget
+//
+//  Created by 김기현 on 10/30/25.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct TodoListWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var emoji: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct TodoListWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TodoListWidgetAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello \(context.state.emoji)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom \(context.state.emoji)")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.emoji)")
+            } minimal: {
+                Text(context.state.emoji)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension TodoListWidgetAttributes {
+    fileprivate static var preview: TodoListWidgetAttributes {
+        TodoListWidgetAttributes(name: "World")
+    }
+}
+
+extension TodoListWidgetAttributes.ContentState {
+    fileprivate static var smiley: TodoListWidgetAttributes.ContentState {
+        TodoListWidgetAttributes.ContentState(emoji: "😀")
+     }
+     
+     fileprivate static var starEyes: TodoListWidgetAttributes.ContentState {
+         TodoListWidgetAttributes.ContentState(emoji: "🤩")
+     }
+}
+
+#Preview("Notification", as: .content, using: TodoListWidgetAttributes.preview) {
+   TodoListWidgetLiveActivity()
+} contentStates: {
+    TodoListWidgetAttributes.ContentState.smiley
+    TodoListWidgetAttributes.ContentState.starEyes
+}

--- a/TodoList/TodoListWidgetExtension.entitlements
+++ b/TodoList/TodoListWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.key.TodoList</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- iOS 위젯 기능 추가 (할 일 진행률 표시)
- App Group을 통한 메인 앱과 위젯 간 Core Data 공유
- 할 일 추가/완료 시 위젯 자동 새로고침

## Changes
- **위젯 확장 프로그램 추가**: TodoListWidget 타겟 생성
- **Core Data 공유**: App Group(`group.key.TodoList`)을 통해 메인 앱과 위젯이 동일한 데이터 접근
- **자동 새로고침**: 할 일 추가/완료/삭제 시 위젯 타임라인 업데이트
- **위젯 UI**: 진행률 바, 완료/전체 개수, 퍼센테지 표시

## Technical Details
- App Group Identifier: `group.key.TodoList`
- 위젯 크기: systemSmall
- 업데이트 주기: 매시간 또는 데이터 변경 시

## Test plan
- [x] 위젯 추가 후 할 일 데이터 표시 확인
- [x] 메인 앱에서 할 일 추가 시 위젯 업데이트 확인
- [x] 메인 앱에서 할 일 완료 시 위젯 업데이트 확인
- [x] 메인 앱에서 할 일 삭제 시 위젯 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)